### PR TITLE
fix requirements.txt (sklearn)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy>=1.19.5
 matplotlib
 iopath
 pyclipper
-sklearn
+scikit-learn
 pyclipper
 imageio-ffmpeg
 polygon3

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ polygon3
 plotly
 rasterio
 levenshtein
+shapely


### PR DESCRIPTION
# Fix requirements.txt

From 2023 December 1st, pypi cannot install scikit-learn package with `sklearn` and we must use `scikit-learn` instead.
So I fixed requirements.txt according that.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
