### PR TITLE
fix importing text_encoder at DatasetMapper

### DIFF
--- a/glass/data/dataset_mapper.py
+++ b/glass/data/dataset_mapper.py
@@ -10,7 +10,7 @@ from detectron2.data import detection_utils as utils
 from detectron2.data import transforms as T
 from detectron2.structures import PolygonMasks, BoxMode
 
-from .text_encoder import TextEncoder
+from ..modeling.recognition.text_encoder import TextEncoder
 from ..utils.common_utils import rgb2grey
 
 


### PR DESCRIPTION
# Fix importing `text_encoder` at `DatasetMapper`

Fixed importing path of `text_encoder`.

Other parts import it correctly, but only `DatasetMapper` does wrong, so I fixed it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
